### PR TITLE
fixed problems when deleting xAxis section in advanced editor

### DIFF
--- a/src/components/data-table.vue
+++ b/src/components/data-table.vue
@@ -147,7 +147,7 @@
                             :aria-label="$t('editor.datatable.addNewCol')"
                         ></td>
                     </tr>
-                    <tr :class="gridData.length % 2 === 0 ? 'bg-gray-50' : ''">
+                    <tr :class="gridData.length % 2 === 0 ? '' : 'bg-gray-50'">
                         <td
                             class="border cursor-pointer border-dotted border-gray-400 p-2 text-center font-bold text-gray-600"
                             @click="addNewRow"

--- a/src/stores/chartStore.ts
+++ b/src/stores/chartStore.ts
@@ -69,6 +69,9 @@ export const useChartStore = defineStore('chartProperties', {
                 },
                 xAxis: {
                     ...chartConfig.xAxis,
+                    categories: Array.isArray(chartConfig.xAxis?.categories)
+                        ? chartConfig.xAxis.categories
+                        : new Array(chartConfig.series?.[0]?.data?.length || 0).fill(''),
                     title: {
                         text: chartConfig.xAxis?.title?.text || ''
                     }
@@ -320,7 +323,6 @@ export const useChartStore = defineStore('chartProperties', {
                 this.chartConfig = {
                     title: {
                         text: this.defaultTitle || ''
-
                     },
                     subtitle: {
                         text: ''


### PR DESCRIPTION
### Related Item(s)
Issue #99 

### Changes
- I made the categories section a default for the x-axis, so even if you delete the section in the advanced editor, the default x-axis template now comes with empty strings for categories so the data table can be correctly displayed and the categories can be replenished

### Testing
Steps:
1. Go to the advanced editor
2. Delete the x-axis section (and the y-axis if you'd like, that part shouldn't affect anything)
3. Go back to data tab
4. Notice the data table still correct, just category labels are cleared

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/106)
<!-- Reviewable:end -->
