### PR TITLE
Ensure highcharts export menu is properly translated

### DIFF
--- a/src/components/chart-selection.vue
+++ b/src/components/chart-selection.vue
@@ -95,7 +95,7 @@
         <div v-if="!loading">
             <div class="font-bold mt-6">{{ $t('HACK.preview') }}</div>
             <div class="dv-chart-container items-stretch h-full w-full mt-2">
-                <highchart :options="chartConfig"></highchart>
+                <highchart :key="chartStore.refreshKey" :options="chartConfig"></highchart>
             </div>
         </div>
 
@@ -124,7 +124,11 @@ import { CurrentView } from '../definitions';
 
 import Highcharts from 'highcharts';
 import dataModule from 'highcharts/modules/data';
+import exporting from 'highcharts/modules/exporting';
+import exportData from 'highcharts/modules/export-data';
 
+exporting(Highcharts);
+exportData(Highcharts);
 dataModule(Highcharts);
 
 const emit = defineEmits(['change-view']);

--- a/src/components/config-customization.vue
+++ b/src/components/config-customization.vue
@@ -111,7 +111,7 @@
             <div class="font-bold mt-6">{{ $t('HACK.preview') }}</div>
             <!-- Preview of chart -->
             <div class="dv-chart-container items-stretch h-full w-full mt-2">
-                <highchart :options="chartConfig"></highchart>
+                <highchart :key="chartStore.refreshKey" :options="chartConfig"></highchart>
             </div>
         </div>
     </div>
@@ -133,7 +133,11 @@ import AxesCustomization from './helpers/axes-customization.vue';
 
 import Highcharts from 'highcharts';
 import dataModule from 'highcharts/modules/data';
+import exporting from 'highcharts/modules/exporting';
+import exportData from 'highcharts/modules/export-data';
 
+exporting(Highcharts);
+exportData(Highcharts);
 dataModule(Highcharts);
 
 const chartStore = useChartStore();

--- a/src/components/data-table.vue
+++ b/src/components/data-table.vue
@@ -168,7 +168,7 @@
         <div class="font-bold mt-8">{{ $t('HACK.preview') }}</div>
         <!-- Preview of chart -->
         <div class="dv-chart-container items-stretch h-full w-full mt-2">
-            <highchart :options="chartConfig"></highchart>
+            <highchart :key="chartStore.refreshKey" :options="chartConfig"></highchart>
         </div>
 
         <div class="flex items-center mt-4">
@@ -197,7 +197,11 @@ import { CurrentView } from '../definitions';
 
 import Highcharts from 'highcharts';
 import dataModule from 'highcharts/modules/data';
+import exporting from 'highcharts/modules/exporting';
+import exportData from 'highcharts/modules/export-data';
 
+exporting(Highcharts);
+exportData(Highcharts);
 dataModule(Highcharts);
 
 const { t } = useI18n();

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -2,6 +2,7 @@ export interface HighchartsConfig {
     chart?: {
         type: string;
     };
+    lang?: ExportMenuOptions;
     title: {
         text: string;
     };
@@ -38,6 +39,19 @@ export interface HighchartsConfig {
     };
     series: SeriesData[] | { data: SeriesData[] };
 }
+
+export interface ExportMenuOptions {
+    viewFullscreen: string;
+    printChart: string;
+    downloadPNG: string;
+    downloadJPEG: string;
+    downloadPDF: string;
+    downloadSVG: string;
+    downloadCSV: string;
+    downloadXLS: string;
+    viewData: string;
+}
+
 export interface SeriesData {
     name: string;
     type: string;

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -31,6 +31,15 @@ HACK.data.paste.label,Use pasted data,1,Utiliser des données collées,1
 HACK.data.paste.description,"Copy data from a CSV or Excel file, then paste in the box below. Please use comma separated values to best avoid errors. Note that the first row should correspond to axis/category titles.",1,"Copiez les données d'un fichier CSV ou Excel, puis collez-les dans le champ ci-dessous. Veuillez utiliser des valeurs séparées par des virgules pour éviter les erreurs. Notez que la premiÃ¨re ligne doit correspondre aux titres des axes/catégories.",1
 HACK.data.paste.placeholder,Paste data here,1,Collez les données ici,1
 HACK.data.modify,"Here, you can modify your dataset. The default standard is that the first column will be reserved for category labels.",1,"Ici, vous pouvez modifier votre ensemble de données. Par défaut, la première colonne est réservée aux libellés des catégories.",1
+HACK.export.viewFullscreen,View in full screen,1,Plein Écran,1
+HACK.export.printChart,Print chart,1,Imprimer,1
+HACK.export.downloadPNG,Download PNG,1,Télécharger PNG,1
+HACK.export.downloadJPEG,Download JPEG,1,Télécharger JPEG,1
+HACK.export.downloadPDF,Download PDF,1,Télécharger PDF,1
+HACK.export.downloadSVG,Download SVG,1,Télécharger SVG,1
+HACK.export.downloadCSV,Download CSV,1,Télécharger CSV,1
+HACK.export.downloadXLS,Download XLS,1,Télécharger XLS,1
+HACK.export.viewData,View data table,1,Afficher le tableau de données,1
 HACK.datatable.uploadNew,Upload new data,1,Télécharger de nouvelles données,1
 HACK.datatable.selectRow,Select row,1,Sélectionner une ligne,1
 HACK.datatable.selectCol,Select column,1,Sélectionner une colonne,1

--- a/src/stores/chartStore.ts
+++ b/src/stores/chartStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import { HighchartsConfig, SeriesData } from '../definitions';
+import { ExportMenuOptions, HighchartsConfig, SeriesData } from '../definitions';
 
 const chartTemplates: Record<string, string> = {
     area: 'area',
@@ -14,6 +14,7 @@ const chartTemplates: Record<string, string> = {
 export const useChartStore = defineStore('chartProperties', {
     state: () => ({
         chartType: 'line' as string,
+        refreshKey: 0 as number,
         defaultTitle: '' as string,
         hybridChartType: '' as string,
         chartSeries: [] as string[],
@@ -74,6 +75,11 @@ export const useChartStore = defineStore('chartProperties', {
         /* Clear highcharts config **/
         clearChartConfig(): void {
             this.chartConfig = {};
+        },
+
+        /* Set context/export menu strings **/
+        setMenuOptions(menuOptions: ExportMenuOptions): void {
+            this.chartConfig.lang = menuOptions;
         },
 
         /* Set highcharts config (from imported json file) **/


### PR DESCRIPTION
### Related Item(s)
Closes #115 

### Changes
- added in export options to preview and properly translated menu strings 

### Notes
Test in RESPECT after all demo derby issues are squashed and a new NPM version is published

### Testing
Steps:
1. Open the export menu for any highcharts preview 
2. Change app lang
3. Re-open the export menu and check lang

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/116)
<!-- Reviewable:end -->
