### PR TITLE
disabled buttons when no data uploaded

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -156,7 +156,6 @@ onMounted(() => {
     if (!props.plugin) {
         i18n.locale.value = appLang.value;
     }
-    chartStore.setMenuOptions(contextMenuLabels.value);
 
     // clear store state (required for shared store state for multi-instance charts)
     if (props.plugin) {

--- a/src/components/chart-selection.vue
+++ b/src/components/chart-selection.vue
@@ -229,7 +229,6 @@ onMounted(() => {
         .slice(1)
         .map((_, colIdx) => dataStore.gridData.map((row) => parseFloat(row[colIdx + 1])));
 
-    chartStore.setupConfig(seriesNames.value, categories, seriesData);
 });
 
 onBeforeUnmount(() => {

--- a/src/components/data-section.vue
+++ b/src/components/data-section.vue
@@ -2,7 +2,22 @@
     <div :class="[{ hidden: hidePage }, 'data-section', 'md:m-6', 'm-2']">
         <div class="text-xl md:text-2xl font-bold">{{ $t('HACK.data.title') }}</div>
         <template v-if="!dataStore.datatableView">
-            <div class="mt-4">{{ $t('HACK.data.description') }}</div>
+            <div class="mt-4 flex flex-col sm:flex-row sm:justify-between sm:items-center">
+                {{ $t('HACK.data.description') }}
+                <button
+                    v-if="!btnDisabled"
+                    class="bg-white border border-black mt-2 rounded hover:bg-gray-100 font-bold p-4 sm:ml-auto"
+                    @click="
+                        () => {
+                            dataStore.setDatatableView(true);
+                            dataStore.toggleUploaded(true);
+                        }
+                    "
+                    :disabled="btnDisabled"
+                >
+                    {{ $t('HACK.label.cancel') }}
+                </button>
+            </div>
 
             <!-- drag and drop section for importing data file -->
             <div
@@ -157,6 +172,8 @@ const fileName = ref<string>('');
 const pastedData = ref<string>('');
 
 const fileInput = ref<HTMLInputElement | null>(null);
+
+const btnDisabled = computed(() => Object.keys(chartStore.chartConfig).length === 0);
 
 const uploadError = ref(false);
 const allowedTypes = [

--- a/src/components/side-menu.vue
+++ b/src/components/side-menu.vue
@@ -385,7 +385,7 @@ const chartStore = useChartStore();
 const dataStore = useDataStore();
 const sidemenuStore = useSidemenuStore();
 const uploaded = computed(() => dataStore.uploaded);
-const btnDisabled = computed(() => !uploaded.value && Object.keys(chartStore.chartConfig).length === 0);
+const btnDisabled = computed(() => (!uploaded.value && Object.keys(chartStore.chartConfig).length === 0) || dataStore.datatableView === false);
 
 const highchartsInput = ref<HTMLInputElement | null>(null);
 


### PR DESCRIPTION
### Related Item(s)
Issue #124 

### Changes
- Other tabs & save chart button should now be properly disabled when no file is uploaded

### Testing
Steps:
1. Launch HACK
2. Only data tab should be enabled until data is uploaded

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/128)
<!-- Reviewable:end -->
