### PR TITLE
Context menu correctly translates in plugin version

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -151,7 +151,7 @@ watch(i18n.locale, () => {
 });
 
 onMounted(() => {
-    appLang.value = props.lang || 'en';
+    appLang.value = i18n.locale.value;
     // set locale only when standalone usage
     if (!props.plugin) {
         i18n.locale.value = appLang.value;
@@ -161,6 +161,7 @@ onMounted(() => {
     if (props.plugin) {
         dataStore.resetStore();
         chartStore.resetStore();
+        chartStore.setMenuOptions(contextMenuLabels.value);
     }
 
     // if passed an existing highcharts config as prop, load and jump to datatable view
@@ -185,6 +186,8 @@ const changeLang = (): void => {
 
 const changeView = (view: CurrentView): void => {
     currentView.value = view;
+    chartStore.setMenuOptions(contextMenuLabels.value);
+    chartStore.refreshKey += 1;
 };
 
 const saveChanges = (): void => {

--- a/src/components/side-menu.vue
+++ b/src/components/side-menu.vue
@@ -385,7 +385,11 @@ const chartStore = useChartStore();
 const dataStore = useDataStore();
 const sidemenuStore = useSidemenuStore();
 const uploaded = computed(() => dataStore.uploaded);
-const btnDisabled = computed(() => (!uploaded.value && Object.keys(chartStore.chartConfig).length === 0) || dataStore.datatableView === false);
+const btnDisabled = computed(() => {
+    const chartKeys = Object.keys(chartStore.chartConfig)
+    const onlyContextMenu = chartKeys.length === 1 && chartKeys[0] === 'lang';
+    return (!uploaded.value && (chartKeys.length === 0 ||  onlyContextMenu)) || dataStore.datatableView === false;
+});
 
 const highchartsInput = ref<HTMLInputElement | null>(null);
 

--- a/src/stores/chartStore.ts
+++ b/src/stores/chartStore.ts
@@ -84,10 +84,12 @@ export const useChartStore = defineStore('chartProperties', {
 
         /** Set highcharts config (from imported json file) */
         setChartConfig(chartConfig: HighchartsConfig): void {
+            const currentLang = this.chartConfig.lang;
             // add mandatory fields blank (for customization section)
             // TODO: tons of edge cases here depending on the complexity of a chart configuration
             this.chartConfig = {
                 ...chartConfig,
+                lang: chartConfig.lang || currentLang,
                 title: {
                     text: chartConfig.title?.text || ''
                 },


### PR DESCRIPTION
### Related Item(s)
Issue #127

### Changes
- In the HACK plugin modal, the context menu should now correctly translate to French

### Notes
- The issue is originally about the chart previews which turns out has to be fixed in the storylines repo, so that will be a separate PR, this PR fixes the context menu inside the modal

### Testing
Steps:
1. build as plugin to RESPECT
2. switch language to French on RESPECT
3. open the HACK modal
4. context menu should be translated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/130)
<!-- Reviewable:end -->
