### PR TITLE
Setting titles and subtitles no longer breaks the program

### DIFF
--- a/src/components/config-customization.vue
+++ b/src/components/config-customization.vue
@@ -223,7 +223,7 @@ const addAriaLabel = () => {
     setTimeout(() => {
         const textarea = document.querySelector('.ace_text-input');
         if (textarea) {
-            textarea.setAttribute('aria-label', t('HACK.customization.advanced.editor'));
+            textarea.setAttribute('aria-label', t('HACK.customization.advanced'));
         }
     }, 0);
 };

--- a/src/stores/chartStore.ts
+++ b/src/stores/chartStore.ts
@@ -84,12 +84,10 @@ export const useChartStore = defineStore('chartProperties', {
 
         /** Set highcharts config (from imported json file) */
         setChartConfig(chartConfig: HighchartsConfig): void {
-            const currentLang = this.chartConfig.lang;
             // add mandatory fields blank (for customization section)
             // TODO: tons of edge cases here depending on the complexity of a chart configuration
             this.chartConfig = {
                 ...chartConfig,
-                lang: chartConfig.lang || currentLang,
                 title: {
                     text: chartConfig.title?.text || ''
                 },


### PR DESCRIPTION
### Changes
- Fixed a problem in setChartConfig that broke the chart when a title or subtitle was added

### Testing
Steps:
1. Edit any properties in advanced editor
2. Chart and datatable should continue working properly and values should still be updating

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/131)
<!-- Reviewable:end -->
