### PR TITLE
Data series tab should work with new columns/columns with the same name

### DIFF
--- a/src/stores/chartStore.ts
+++ b/src/stores/chartStore.ts
@@ -145,7 +145,7 @@ export const useChartStore = defineStore('chartProperties', {
                     name: seriesName,
                     data: values.slice(1).map((val: string) => parseInt(val)),
                     type: 'line',
-                    color: this.defaultColours[i-1],
+                    color: this.defaultColours[i - 1],
                     dashStyle: 'solid',
                     marker: {
                         symbol: 'circle'
@@ -322,6 +322,11 @@ export const useChartStore = defineStore('chartProperties', {
             const newSeries: SeriesData = {
                 name: 'Untitled',
                 type: this.chartType,
+                color: this.defaultColours[colIdx],
+                dashStyle: 'solid',
+                marker: {
+                    symbol: 'circle'
+                },
                 data: defaultData
             };
             (this.chartConfig.series as SeriesData[]).splice(colIdx - 1, 0, newSeries);

--- a/src/stores/dataStore.ts
+++ b/src/stores/dataStore.ts
@@ -116,13 +116,13 @@ export const useDataStore = defineStore('chartData', {
 
         /** Add new column to grid data */
         addNewCol(selectedColIdx: string, right: boolean = true): void {
-            const newCol = '';
+            const newCol = 'Untitled';
             // determine new position based on insert right/left
             const newIdx = right ? parseInt(selectedColIdx) + 1 : parseInt(selectedColIdx);
             // add new header and empty col of values
             this.headers.splice(newIdx, 0, newCol);
             this.gridData.forEach((row) => {
-                row.splice(newIdx, 0, '');
+                row.splice(newIdx, 0, '0');
             });
         }
     }


### PR DESCRIPTION
### Related Item(s)
Issues #132, #137 
### Changes
- New columns added also sets a default for all styles so there is no reading undefined values
- Columns with the same name should now work as intended, using index instead of name to loop through

### Testing
Steps:
1. Add new columns 
2. Name two or more columns the same name
3. Go to customization -> data series
4. Mess around and see if everything works as intended!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/138)
<!-- Reviewable:end -->
