### PR TITLE
Plugin save chart button now properly disables

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -32,8 +32,8 @@
             <button
                 @click="saveChanges"
                 class="bg-black border rounded text-sm md:text-base border-black text-white hover:bg-gray-900 font-bold p-2"
-                :class="{ 'disabled hover:bg-gray-400': Object.keys(chartStore.chartConfig).length === 0 }"
-                :disabled="Object.keys(chartStore.chartConfig).length === 0"
+                :class="{ 'disabled hover:bg-gray-400': dataStore.datatableView === false }"
+                :disabled="dataStore.datatableView === false"
             >
                 {{ $t('HACK.saveChanges') }}
                 <span v-if="saving" class="align-middle inline-block px-1">


### PR DESCRIPTION
### Related Item(s)
Issue #145 

### Changes
On RESPECT, save chart button should now only be enabled once a file is actually imported, like in standalone

### Testing
Steps:
1. Import as plugin to RESPECT
2. Add a new chart
3. Try to save the chart before importing data from a file
4. Shouldn't work — only charts with data should be able to be saved

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/146)
<!-- Reviewable:end -->
